### PR TITLE
Runs every transaction in a snapshot in assembleBlock handler

### DIFF
--- a/eth/catalyst/api.go
+++ b/eth/catalyst/api.go
@@ -113,8 +113,10 @@ type blockExecutionEnv struct {
 
 func (env *blockExecutionEnv) commitTransaction(tx *types.Transaction, coinbase common.Address) error {
 	vmconfig := *env.chain.GetVMConfig()
+	snap := env.state.Snapshot()
 	receipt, err := core.ApplyTransaction(env.chain.Config(), env.chain, &coinbase, env.gasPool, env.state, env.header, tx, &env.header.GasUsed, vmconfig)
 	if err != nil {
+		env.state.RevertToSnapshot(snap)
 		return err
 	}
 	env.txs = append(env.txs, tx)


### PR DESCRIPTION
Creates state snapshot before applying a transaction in `consensus_assembleBlock` handler and reverts the state back to it in case of error