### PR TITLE
core/state, trie/bintrie: read contract code from binary trie

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -91,9 +91,7 @@ var (
 	accountReadSingleTimer = metrics.NewRegisteredResettingTimer("chain/account/single/reads", nil)
 	storageReadSingleTimer = metrics.NewRegisteredResettingTimer("chain/storage/single/reads", nil)
 	codeReadSingleTimer    = metrics.NewRegisteredResettingTimer("chain/code/single/reads", nil)
-
-	snapshotCommitTimer = metrics.NewRegisteredResettingTimer("chain/snapshot/commits", nil)
-	triedbCommitTimer   = metrics.NewRegisteredResettingTimer("chain/triedb/commits", nil)
+	triedbCommitTimer      = metrics.NewRegisteredResettingTimer("chain/triedb/commits", nil)
 
 	blockInsertTimer          = metrics.NewRegisteredResettingTimer("chain/inserts", nil)
 	blockValidationTimer      = metrics.NewRegisteredResettingTimer("chain/validation", nil)
@@ -320,7 +318,7 @@ type BlockChain struct {
 	lastWrite     uint64                           // Last block when the state was flushed
 	flushInterval atomic.Int64                     // Time interval (processing time) after which to flush a state
 	triedb        *triedb.Database                 // The database handler for maintaining trie nodes.
-	statedb       *state.CachingDB                 // State database to reuse between imports (contains state cache)
+	codedb        *state.CodeDB                    // The database handler for maintaining contract codes.
 	txIndexer     *txIndexer                       // Transaction indexer, might be nil if not enabled
 
 	hc               *HeaderChain
@@ -402,6 +400,7 @@ func NewBlockChain(db ethdb.Database, genesis *Genesis, engine consensus.Engine,
 		cfg:                cfg,
 		db:                 db,
 		triedb:             triedb,
+		codedb:             state.NewCodeDB(db),
 		triegc:             prque.New[int64, common.Hash](nil),
 		chainmu:            syncx.NewClosableMutex(),
 		bodyCache:          lru.NewCache[common.Hash, *types.Body](bodyCacheLimit),
@@ -418,7 +417,6 @@ func NewBlockChain(db ethdb.Database, genesis *Genesis, engine consensus.Engine,
 		return nil, err
 	}
 	bc.flushInterval.Store(int64(cfg.TrieTimeLimit))
-	bc.statedb = state.NewDatabase(bc.triedb, nil)
 	bc.validator = NewBlockValidator(chainConfig, bc)
 	bc.prefetcher = newStatePrefetcher(chainConfig, bc.hc)
 	bc.processor = NewStateProcessor(bc.hc)
@@ -595,9 +593,6 @@ func (bc *BlockChain) setupSnapshot() {
 			AsyncBuild: !bc.cfg.SnapshotWait,
 		}
 		bc.snaps, _ = snapshot.New(snapconfig, bc.db, bc.triedb, head.Root)
-
-		// Re-initialize the state database with snapshot
-		bc.statedb = state.NewDatabase(bc.triedb, bc.snaps)
 	}
 }
 
@@ -2079,11 +2074,12 @@ func (bc *BlockChain) ProcessBlock(parentRoot common.Hash, block *types.Block, s
 		startTime = time.Now()
 		statedb   *state.StateDB
 		interrupt atomic.Bool
+		sdb       = state.NewDatabase(bc.triedb, bc.codedb).WithSnapshot(bc.snaps)
 	)
 	defer interrupt.Store(true) // terminate the prefetch at the end
 
 	if bc.cfg.NoPrefetch {
-		statedb, err = state.New(parentRoot, bc.statedb)
+		statedb, err = state.New(parentRoot, sdb)
 		if err != nil {
 			return nil, err
 		}
@@ -2093,15 +2089,15 @@ func (bc *BlockChain) ProcessBlock(parentRoot common.Hash, block *types.Block, s
 		//
 		// Note: the main processor and prefetcher share the same reader with a local
 		// cache for mitigating the overhead of state access.
-		prefetch, process, err := bc.statedb.ReadersWithCacheStats(parentRoot)
+		prefetch, process, err := sdb.ReadersWithCacheStats(parentRoot)
 		if err != nil {
 			return nil, err
 		}
-		throwaway, err := state.NewWithReader(parentRoot, bc.statedb, prefetch)
+		throwaway, err := state.NewWithReader(parentRoot, sdb, prefetch)
 		if err != nil {
 			return nil, err
 		}
-		statedb, err = state.NewWithReader(parentRoot, bc.statedb, process)
+		statedb, err = state.NewWithReader(parentRoot, sdb, process)
 		if err != nil {
 			return nil, err
 		}
@@ -2262,9 +2258,8 @@ func (bc *BlockChain) ProcessBlock(parentRoot common.Hash, block *types.Block, s
 	// Update the metrics touched during block commit
 	stats.AccountCommits = statedb.AccountCommits  // Account commits are complete, we can mark them
 	stats.StorageCommits = statedb.StorageCommits  // Storage commits are complete, we can mark them
-	stats.SnapshotCommit = statedb.SnapshotCommits // Snapshot commits are complete, we can mark them
-	stats.TrieDBCommit = statedb.TrieDBCommits     // Trie database commits are complete, we can mark them
-	stats.BlockWrite = time.Since(wstart) - max(statedb.AccountCommits, statedb.StorageCommits) /* concurrent */ - statedb.SnapshotCommits - statedb.TrieDBCommits
+	stats.DatabaseCommit = statedb.DatabaseCommits // Database commits are complete, we can mark them
+	stats.BlockWrite = time.Since(wstart) - max(statedb.AccountCommits, statedb.StorageCommits) /* concurrent */ - statedb.DatabaseCommits
 
 	elapsed := time.Since(startTime) + 1 // prevent zero division
 	stats.TotalTime = elapsed

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -2108,8 +2108,12 @@ func (bc *BlockChain) ProcessBlock(parentRoot common.Hash, block *types.Block, s
 		// Upload the statistics of reader at the end
 		defer func() {
 			if result != nil {
-				result.stats.StatePrefetchCacheStats = prefetch.GetStats()
-				result.stats.StateReadCacheStats = process.GetStats()
+				if stater, ok := prefetch.(state.ReaderStater); ok {
+					result.stats.StatePrefetchCacheStats = stater.GetStats()
+				}
+				if stater, ok := process.(state.ReaderStater); ok {
+					result.stats.StateReadCacheStats = stater.GetStats()
+				}
 			}
 		}()
 		go func(start time.Time, throwaway *state.StateDB, block *types.Block) {

--- a/core/blockchain_sethead_test.go
+++ b/core/blockchain_sethead_test.go
@@ -30,7 +30,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/consensus/ethash"
 	"github.com/ethereum/go-ethereum/core/rawdb"
-	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/ethdb/pebble"
 	"github.com/ethereum/go-ethereum/params"
@@ -2041,7 +2040,6 @@ func testSetHeadWithScheme(t *testing.T, tt *rewindTest, snapshots bool, scheme 
 		dbconfig.HashDB = hashdb.Defaults
 	}
 	chain.triedb = triedb.NewDatabase(chain.db, dbconfig)
-	chain.statedb = state.NewDatabase(chain.triedb, chain.snaps)
 
 	// Force run a freeze cycle
 	type freezer interface {

--- a/core/blockchain_stats.go
+++ b/core/blockchain_stats.go
@@ -52,8 +52,7 @@ type ExecuteStats struct {
 	Execution       time.Duration // Time spent on the EVM execution
 	Validation      time.Duration // Time spent on the block validation
 	CrossValidation time.Duration // Optional, time spent on the block cross validation
-	SnapshotCommit  time.Duration // Time spent on snapshot commit
-	TrieDBCommit    time.Duration // Time spent on database commit
+	DatabaseCommit  time.Duration // Time spent on database commit
 	BlockWrite      time.Duration // Time spent on block write
 	TotalTime       time.Duration // The total time spent on block execution
 	MgasPerSecond   float64       // The million gas processed per second
@@ -87,8 +86,7 @@ func (s *ExecuteStats) reportMetrics() {
 	blockExecutionTimer.Update(s.Execution)                 // The time spent on EVM processing
 	blockValidationTimer.Update(s.Validation)               // The time spent on block validation
 	blockCrossValidationTimer.Update(s.CrossValidation)     // The time spent on stateless cross validation
-	snapshotCommitTimer.Update(s.SnapshotCommit)            // Snapshot commits are complete, we can mark them
-	triedbCommitTimer.Update(s.TrieDBCommit)                // Trie database commits are complete, we can mark them
+	triedbCommitTimer.Update(s.DatabaseCommit)              // Trie database commits are complete, we can mark them
 	blockWriteTimer.Update(s.BlockWrite)                    // The time spent on block write
 	blockInsertTimer.Update(s.TotalTime)                    // The total time spent on block execution
 	chainMgaspsMeter.Update(time.Duration(s.MgasPerSecond)) // TODO(rjl493456442) generalize the ResettingTimer
@@ -208,7 +206,7 @@ func (s *ExecuteStats) logSlow(block *types.Block, slowBlockThreshold time.Durat
 			ExecutionMs: durationToMs(s.Execution),
 			StateReadMs: durationToMs(s.AccountReads + s.StorageReads + s.CodeReads),
 			StateHashMs: durationToMs(s.AccountHashes + s.AccountUpdates + s.StorageUpdates),
-			CommitMs:    durationToMs(max(s.AccountCommits, s.StorageCommits) + s.TrieDBCommit + s.SnapshotCommit + s.BlockWrite),
+			CommitMs:    durationToMs(max(s.AccountCommits, s.StorageCommits) + s.DatabaseCommit + s.BlockWrite),
 			TotalMs:     durationToMs(s.TotalTime),
 		},
 		Throughput: slowBlockThru{

--- a/core/blockchain_test.go
+++ b/core/blockchain_test.go
@@ -156,7 +156,7 @@ func testBlockChainImport(chain types.Blocks, blockchain *BlockChain) error {
 			}
 			return err
 		}
-		statedb, err := state.New(blockchain.GetBlockByHash(block.ParentHash()).Root(), blockchain.statedb)
+		statedb, err := state.New(blockchain.GetBlockByHash(block.ParentHash()).Root(), state.NewDatabase(blockchain.triedb, blockchain.codedb))
 		if err != nil {
 			return err
 		}

--- a/core/state/database.go
+++ b/core/state/database.go
@@ -224,15 +224,14 @@ func (db *CachingDB) Reader(stateRoot common.Hash) (Reader, error) {
 // ReadersWithCacheStats creates a pair of state readers that share the same
 // underlying state reader and internal state cache, while maintaining separate
 // statistics respectively.
-func (db *CachingDB) ReadersWithCacheStats(stateRoot common.Hash) (ReaderWithStats, ReaderWithStats, error) {
+func (db *CachingDB) ReadersWithCacheStats(stateRoot common.Hash) (Reader, Reader, error) {
 	r, err := db.StateReader(stateRoot)
 	if err != nil {
 		return nil, nil, err
 	}
 	sr := newStateReaderWithCache(r)
-
-	ra := newReaderWithStats(sr, newCachingCodeReader(db.disk, db.codeCache, db.codeSizeCache))
-	rb := newReaderWithStats(sr, newCachingCodeReader(db.disk, db.codeCache, db.codeSizeCache))
+	ra := newReader(newCachingCodeReader(db.disk, db.codeCache, db.codeSizeCache), newStateReaderWithStats(sr))
+	rb := newReader(newCachingCodeReader(db.disk, db.codeCache, db.codeSizeCache), newStateReaderWithStats(sr))
 	return ra, rb, nil
 }
 

--- a/core/state/database.go
+++ b/core/state/database.go
@@ -20,26 +20,18 @@ import (
 	"fmt"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/common/lru"
 	"github.com/ethereum/go-ethereum/core/overlay"
 	"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/ethereum/go-ethereum/core/state/snapshot"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/ethdb"
+	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/trie"
 	"github.com/ethereum/go-ethereum/trie/bintrie"
 	"github.com/ethereum/go-ethereum/trie/transitiontrie"
 	"github.com/ethereum/go-ethereum/trie/trienode"
 	"github.com/ethereum/go-ethereum/triedb"
-)
-
-const (
-	// Number of codehash->size associations to keep.
-	codeSizeCacheSize = 1_000_000 // 4 megabytes in total
-
-	// Cache size granted for caching clean code.
-	codeCacheSize = 256 * 1024 * 1024
 )
 
 // Database wraps access to tries and contract code.
@@ -58,6 +50,11 @@ type Database interface {
 
 	// Snapshot returns the underlying state snapshot.
 	Snapshot() *snapshot.Tree
+
+	// Commit flushes all pending writes and finalizes the state transition,
+	// committing the changes to the underlying storage. It returns an error
+	// if the commit fails.
+	Commit(update *stateUpdate) error
 }
 
 // Trie is a Ethereum Merkle Patricia trie.
@@ -149,32 +146,34 @@ type Trie interface {
 // state snapshot to provide functionalities for state access. It's meant to be a
 // long-live object and has a few caches inside for sharing between blocks.
 type CachingDB struct {
-	disk          ethdb.KeyValueStore
-	triedb        *triedb.Database
-	snap          *snapshot.Tree
-	codeCache     *lru.SizeConstrainedCache[common.Hash, []byte]
-	codeSizeCache *lru.Cache[common.Hash, int]
-
-	// Transition-specific fields
-	TransitionStatePerRoot *lru.Cache[common.Hash, *overlay.TransitionState]
+	triedb *triedb.Database
+	codedb *CodeDB
+	snap   *snapshot.Tree
 }
 
 // NewDatabase creates a state database with the provided data sources.
-func NewDatabase(triedb *triedb.Database, snap *snapshot.Tree) *CachingDB {
+func NewDatabase(triedb *triedb.Database, codedb *CodeDB) *CachingDB {
+	if codedb == nil {
+		codedb = NewCodeDB(triedb.Disk())
+	}
 	return &CachingDB{
-		disk:                   triedb.Disk(),
-		triedb:                 triedb,
-		snap:                   snap,
-		codeCache:              lru.NewSizeConstrainedCache[common.Hash, []byte](codeCacheSize),
-		codeSizeCache:          lru.NewCache[common.Hash, int](codeSizeCacheSize),
-		TransitionStatePerRoot: lru.NewCache[common.Hash, *overlay.TransitionState](1000),
+		triedb: triedb,
+		codedb: codedb,
 	}
 }
 
 // NewDatabaseForTesting is similar to NewDatabase, but it initializes the caching
 // db by using an ephemeral memory db with default config for testing.
 func NewDatabaseForTesting() *CachingDB {
-	return NewDatabase(triedb.NewDatabase(rawdb.NewMemoryDatabase(), nil), nil)
+	db := rawdb.NewMemoryDatabase()
+	return NewDatabase(triedb.NewDatabase(db, nil), NewCodeDB(db))
+}
+
+// WithSnapshot configures the provided contract code cache. Note that this
+// registration must be performed before the cachingDB is used.
+func (db *CachingDB) WithSnapshot(snapshot *snapshot.Tree) *CachingDB {
+	db.snap = snapshot
+	return db
 }
 
 // StateReader returns a state reader associated with the specified state root.
@@ -218,7 +217,7 @@ func (db *CachingDB) Reader(stateRoot common.Hash) (Reader, error) {
 	if err != nil {
 		return nil, err
 	}
-	return newReader(newCachingCodeReader(db.disk, db.codeCache, db.codeSizeCache), sr), nil
+	return newReader(db.codedb.Reader(), sr), nil
 }
 
 // ReadersWithCacheStats creates a pair of state readers that share the same
@@ -230,8 +229,8 @@ func (db *CachingDB) ReadersWithCacheStats(stateRoot common.Hash) (Reader, Reade
 		return nil, nil, err
 	}
 	sr := newStateReaderWithCache(r)
-	ra := newReader(newCachingCodeReader(db.disk, db.codeCache, db.codeSizeCache), newStateReaderWithStats(sr))
-	rb := newReader(newCachingCodeReader(db.disk, db.codeCache, db.codeSizeCache), newStateReaderWithStats(sr))
+	ra := newReader(db.codedb.Reader(), newStateReaderWithStats(sr))
+	rb := newReader(db.codedb.Reader(), newStateReaderWithStats(sr))
 	return ra, rb, nil
 }
 
@@ -267,22 +266,6 @@ func (db *CachingDB) OpenStorageTrie(stateRoot common.Hash, address common.Addre
 	return tr, nil
 }
 
-// ContractCodeWithPrefix retrieves a particular contract's code. If the
-// code can't be found in the cache, then check the existence with **new**
-// db scheme.
-func (db *CachingDB) ContractCodeWithPrefix(address common.Address, codeHash common.Hash) []byte {
-	code, _ := db.codeCache.Get(codeHash)
-	if len(code) > 0 {
-		return code
-	}
-	code = rawdb.ReadCodeWithPrefix(db.disk, codeHash)
-	if len(code) > 0 {
-		db.codeCache.Add(codeHash, code)
-		db.codeSizeCache.Add(codeHash, len(code))
-	}
-	return code
-}
-
 // TrieDB retrieves any intermediate trie-node caching layer.
 func (db *CachingDB) TrieDB() *triedb.Database {
 	return db.triedb
@@ -291,6 +274,40 @@ func (db *CachingDB) TrieDB() *triedb.Database {
 // Snapshot returns the underlying state snapshot.
 func (db *CachingDB) Snapshot() *snapshot.Tree {
 	return db.snap
+}
+
+// Commit flushes all pending writes and finalizes the state transition,
+// committing the changes to the underlying storage. It returns an error
+// if the commit fails.
+func (db *CachingDB) Commit(update *stateUpdate) error {
+	// Short circuit if nothing to commit
+	if update.empty() {
+		return nil
+	}
+	// Commit dirty contract code if any exists
+	if len(update.codes) > 0 {
+		batch := db.codedb.NewBatchWithSize(len(update.codes))
+		for _, code := range update.codes {
+			batch.Put(code.hash, code.blob)
+		}
+		if err := batch.Commit(); err != nil {
+			return err
+		}
+	}
+	// If snapshotting is enabled, update the snapshot tree with this new version
+	if db.snap != nil && db.snap.Snapshot(update.originRoot) != nil {
+		if err := db.snap.Update(update.root, update.originRoot, update.accounts, update.storages); err != nil {
+			log.Warn("Failed to update snapshot tree", "from", update.originRoot, "to", update.root, "err", err)
+		}
+		// Keep 128 diff layers in the memory, persistent layer is 129th.
+		// - head layer is paired with HEAD state
+		// - head-1 layer is paired with HEAD-1 state
+		// - head-127 layer(bottom-most diff layer) is paired with HEAD-127 state
+		if err := db.snap.Cap(update.root, TriesInMemory); err != nil {
+			log.Warn("Failed to cap snapshot tree", "root", update.root, "layers", TriesInMemory, "err", err)
+		}
+	}
+	return db.triedb.Update(update.root, update.originRoot, update.blockNumber, update.nodes, update.stateSet())
 }
 
 // mustCopyTrie returns a deep-copied trie.

--- a/core/state/database.go
+++ b/core/state/database.go
@@ -108,6 +108,15 @@ type Trie interface {
 	// to be moved to the stateWriter interface when the latter is ready.
 	UpdateContractCode(address common.Address, codeHash common.Hash, code []byte) error
 
+	// GetContractCode retrieves the contract code from the trie. For MPT this
+	// returns nil (code is stored separately). For binary tries, code is stored
+	// in the trie itself as chunks.
+	GetContractCode(addr common.Address, codeHash common.Hash) ([]byte, error)
+
+	// GetContractCodeSize returns the code size from the trie header without
+	// reading chunks. Returns 0 for MPT (code size is stored separately).
+	GetContractCodeSize(addr common.Address) (int, error)
+
 	// Hash returns the root hash of the trie. It does not write to the database and
 	// can be used even if the trie doesn't have one.
 	Hash() common.Hash
@@ -284,8 +293,9 @@ func (db *CachingDB) Commit(update *stateUpdate) error {
 	if update.empty() {
 		return nil
 	}
-	// Commit dirty contract code if any exists
-	if len(update.codes) > 0 {
+	// Commit dirty contract code if any exists (skip for verkle/binary trie,
+	// where code is stored in the trie itself)
+	if len(update.codes) > 0 && !db.triedb.IsVerkle() {
 		batch := db.codedb.NewBatchWithSize(len(update.codes))
 		for _, code := range update.codes {
 			batch.Put(code.hash, code.blob)

--- a/core/state/database_code.go
+++ b/core/state/database_code.go
@@ -1,0 +1,231 @@
+// Copyright 2026 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package state
+
+import (
+	"sync/atomic"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/lru"
+	"github.com/ethereum/go-ethereum/core/rawdb"
+	"github.com/ethereum/go-ethereum/ethdb"
+)
+
+const (
+	// Number of codeHash->size associations to keep.
+	codeSizeCacheSize = 1_000_000
+
+	// Cache size granted for caching clean code.
+	codeCacheSize = 256 * 1024 * 1024
+)
+
+// CodeCache maintains cached contract code that is shared across blocks, enabling
+// fast access for external calls such as RPCs and state transitions.
+//
+// It is thread-safe and has a bounded size.
+type codeCache struct {
+	codeCache     *lru.SizeConstrainedCache[common.Hash, []byte]
+	codeSizeCache *lru.Cache[common.Hash, int]
+}
+
+// newCodeCache initializes the contract code cache with the predefined capacity.
+func newCodeCache() *codeCache {
+	return &codeCache{
+		codeCache:     lru.NewSizeConstrainedCache[common.Hash, []byte](codeCacheSize),
+		codeSizeCache: lru.NewCache[common.Hash, int](codeSizeCacheSize),
+	}
+}
+
+// Get returns the contract code associated with the provided code hash.
+func (c *codeCache) Get(hash common.Hash) ([]byte, bool) {
+	return c.codeCache.Get(hash)
+}
+
+// GetSize returns the contract code size associated with the provided code hash.
+func (c *codeCache) GetSize(hash common.Hash) (int, bool) {
+	return c.codeSizeCache.Get(hash)
+}
+
+// Put adds the provided contract code along with its size information into the cache.
+func (c *codeCache) Put(hash common.Hash, code []byte) {
+	c.codeCache.Add(hash, code)
+	c.codeSizeCache.Add(hash, len(code))
+}
+
+// CodeReader implements state.ContractCodeReader, accessing contract code either in
+// local key-value store or the shared code cache.
+//
+// Reader is safe for concurrent access.
+type CodeReader struct {
+	db    ethdb.KeyValueReader
+	cache *codeCache
+
+	// Cache statistics
+	hit       atomic.Int64 // Number of code lookups found in the cache
+	miss      atomic.Int64 // Number of code lookups not found in the cache
+	hitBytes  atomic.Int64 // Total number of bytes read from cache
+	missBytes atomic.Int64 // Total number of bytes read from database
+}
+
+// newCodeReader constructs the code reader with provided key value store and the cache.
+func newCodeReader(db ethdb.KeyValueReader, cache *codeCache) *CodeReader {
+	return &CodeReader{
+		db:    db,
+		cache: cache,
+	}
+}
+
+// Has returns the flag indicating whether the contract code with
+// specified address and hash exists or not.
+func (r *CodeReader) Has(addr common.Address, codeHash common.Hash) bool {
+	return len(r.Code(addr, codeHash)) > 0
+}
+
+// Code implements state.ContractCodeReader, retrieving a particular contract's code.
+// Null is returned if the contract code is not present.
+func (r *CodeReader) Code(addr common.Address, codeHash common.Hash) []byte {
+	code, _ := r.cache.Get(codeHash)
+	if len(code) > 0 {
+		r.hit.Add(1)
+		r.hitBytes.Add(int64(len(code)))
+		return code
+	}
+	r.miss.Add(1)
+
+	code = rawdb.ReadCode(r.db, codeHash)
+	if len(code) > 0 {
+		r.cache.Put(codeHash, code)
+		r.missBytes.Add(int64(len(code)))
+	}
+	return code
+}
+
+// CodeSize implements state.ContractCodeReader, retrieving a particular contract
+// code's size. Zero is returned if the contract code is not present.
+func (r *CodeReader) CodeSize(addr common.Address, codeHash common.Hash) int {
+	if cached, ok := r.cache.GetSize(codeHash); ok {
+		r.hit.Add(1)
+		return cached
+	}
+	return len(r.Code(addr, codeHash))
+}
+
+// CodeWithPrefix retrieves the contract code for the specified account address
+// and code hash. It is almost identical to Code, but uses rawdb.ReadCodeWithPrefix
+// for database lookups. The intention is to gradually deprecate the old
+// contract code scheme.
+func (r *CodeReader) CodeWithPrefix(addr common.Address, codeHash common.Hash) []byte {
+	code, _ := r.cache.Get(codeHash)
+	if len(code) > 0 {
+		r.hit.Add(1)
+		r.hitBytes.Add(int64(len(code)))
+		return code
+	}
+	r.miss.Add(1)
+
+	code = rawdb.ReadCodeWithPrefix(r.db, codeHash)
+	if len(code) > 0 {
+		r.cache.Put(codeHash, code)
+		r.missBytes.Add(int64(len(code)))
+	}
+	return code
+}
+
+// GetCodeStats implements ContractCodeReaderStater, returning the statistics
+// of the code reader.
+func (r *CodeReader) GetCodeStats() ContractCodeReaderStats {
+	return ContractCodeReaderStats{
+		CacheHit:       r.hit.Load(),
+		CacheMiss:      r.miss.Load(),
+		CacheHitBytes:  r.hitBytes.Load(),
+		CacheMissBytes: r.missBytes.Load(),
+	}
+}
+
+type CodeBatch struct {
+	db         *CodeDB
+	codes      [][]byte
+	codeHashes []common.Hash
+}
+
+// newCodeBatch constructs the batch for writing contract code.
+func newCodeBatch(db *CodeDB) *CodeBatch {
+	return &CodeBatch{
+		db: db,
+	}
+}
+
+// newCodeBatchWithSize constructs the batch with a pre-allocated capacity.
+func newCodeBatchWithSize(db *CodeDB, size int) *CodeBatch {
+	return &CodeBatch{
+		db:         db,
+		codes:      make([][]byte, 0, size),
+		codeHashes: make([]common.Hash, 0, size),
+	}
+}
+
+// Put inserts the given contract code into the writer, waiting for commit.
+func (b *CodeBatch) Put(codeHash common.Hash, code []byte) {
+	b.codes = append(b.codes, code)
+	b.codeHashes = append(b.codeHashes, codeHash)
+}
+
+// Commit flushes the accumulated dirty contract code into the database and
+// also place them in the cache.
+func (b *CodeBatch) Commit() error {
+	batch := b.db.db.NewBatch()
+	for i, code := range b.codes {
+		rawdb.WriteCode(batch, b.codeHashes[i], code)
+		b.db.cache.Put(b.codeHashes[i], code)
+	}
+	if err := batch.Write(); err != nil {
+		return err
+	}
+	b.codes = b.codes[:0]
+	b.codeHashes = b.codeHashes[:0]
+	return nil
+}
+
+// CodeDB is responsible for managing the contract code and provides the access
+// to it. It can be used as a global object, sharing it between multiple entities.
+type CodeDB struct {
+	db    ethdb.KeyValueStore
+	cache *codeCache
+}
+
+// NewCodeDB constructs the contract code database with the provided key value store.
+func NewCodeDB(db ethdb.KeyValueStore) *CodeDB {
+	return &CodeDB{
+		db:    db,
+		cache: newCodeCache(),
+	}
+}
+
+// Reader returns the contract code reader.
+func (d *CodeDB) Reader() *CodeReader {
+	return newCodeReader(d.db, d.cache)
+}
+
+// NewBatch returns the batch for flushing contract codes.
+func (d *CodeDB) NewBatch() *CodeBatch {
+	return newCodeBatch(d)
+}
+
+// NewBatchWithSize returns the batch with pre-allocated capacity.
+func (d *CodeDB) NewBatchWithSize(size int) *CodeBatch {
+	return newCodeBatchWithSize(d, size)
+}

--- a/core/state/iterator.go
+++ b/core/state/iterator.go
@@ -144,10 +144,7 @@ func (it *nodeIterator) step() error {
 	}
 	if !bytes.Equal(account.CodeHash, types.EmptyCodeHash.Bytes()) {
 		it.codeHash = common.BytesToHash(account.CodeHash)
-		it.code, err = it.state.reader.Code(address, common.BytesToHash(account.CodeHash))
-		if err != nil {
-			return fmt.Errorf("code %x: %v", account.CodeHash, err)
-		}
+		it.code = it.state.reader.Code(address, common.BytesToHash(account.CodeHash))
 		if len(it.code) == 0 {
 			return fmt.Errorf("code is not found: %x", account.CodeHash)
 		}

--- a/core/state/reader_stater.go
+++ b/core/state/reader_stater.go
@@ -1,0 +1,82 @@
+// Copyright 2026 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package state
+
+// ContractCodeReaderStats aggregates statistics for the contract code reader.
+type ContractCodeReaderStats struct {
+	CacheHit       int64 // Number of cache hits
+	CacheMiss      int64 // Number of cache misses
+	CacheHitBytes  int64 // Total bytes served from cache
+	CacheMissBytes int64 // Total bytes read on cache misses
+}
+
+// HitRate returns the cache hit rate in percentage.
+func (s ContractCodeReaderStats) HitRate() float64 {
+	total := s.CacheHit + s.CacheMiss
+	if total == 0 {
+		return 0
+	}
+	return float64(s.CacheHit) / float64(total) * 100
+}
+
+// ContractCodeReaderStater wraps the method to retrieve the statistics of
+// contract code reader.
+type ContractCodeReaderStater interface {
+	GetCodeStats() ContractCodeReaderStats
+}
+
+// StateReaderStats aggregates statistics for the state reader.
+type StateReaderStats struct {
+	AccountCacheHit  int64 // Number of account cache hits
+	AccountCacheMiss int64 // Number of account cache misses
+	StorageCacheHit  int64 // Number of storage cache hits
+	StorageCacheMiss int64 // Number of storage cache misses
+}
+
+// AccountCacheHitRate returns the cache hit rate of account requests in percentage.
+func (s StateReaderStats) AccountCacheHitRate() float64 {
+	total := s.AccountCacheHit + s.AccountCacheMiss
+	if total == 0 {
+		return 0
+	}
+	return float64(s.AccountCacheHit) / float64(total) * 100
+}
+
+// StorageCacheHitRate returns the cache hit rate of storage requests in percentage.
+func (s StateReaderStats) StorageCacheHitRate() float64 {
+	total := s.StorageCacheHit + s.StorageCacheMiss
+	if total == 0 {
+		return 0
+	}
+	return float64(s.StorageCacheHit) / float64(total) * 100
+}
+
+// StateReaderStater wraps the method to retrieve the statistics of state reader.
+type StateReaderStater interface {
+	GetStateStats() StateReaderStats
+}
+
+// ReaderStats wraps the statistics of reader.
+type ReaderStats struct {
+	CodeStats  ContractCodeReaderStats
+	StateStats StateReaderStats
+}
+
+// ReaderStater defines the capability to retrieve aggregated statistics.
+type ReaderStater interface {
+	GetStats() ReaderStats
+}

--- a/core/state/state_object.go
+++ b/core/state/state_object.go
@@ -551,10 +551,7 @@ func (s *stateObject) Code() []byte {
 		s.db.CodeLoadBytes += len(s.code)
 	}(time.Now())
 
-	code, err := s.db.reader.Code(s.address, common.BytesToHash(s.CodeHash()))
-	if err != nil {
-		s.db.setError(fmt.Errorf("can't load code hash %x: %v", s.CodeHash(), err))
-	}
+	code := s.db.reader.Code(s.address, common.BytesToHash(s.CodeHash()))
 	if len(code) == 0 {
 		s.db.setError(fmt.Errorf("code is not found %x", s.CodeHash()))
 	}
@@ -577,10 +574,7 @@ func (s *stateObject) CodeSize() int {
 		s.db.CodeReads += time.Since(start)
 	}(time.Now())
 
-	size, err := s.db.reader.CodeSize(s.address, common.BytesToHash(s.CodeHash()))
-	if err != nil {
-		s.db.setError(fmt.Errorf("can't load code size %x: %v", s.CodeHash(), err))
-	}
+	size := s.db.reader.CodeSize(s.address, common.BytesToHash(s.CodeHash()))
 	if size == 0 {
 		s.db.setError(fmt.Errorf("code is not found %x", s.CodeHash()))
 	}

--- a/core/state/state_object.go
+++ b/core/state/state_object.go
@@ -551,6 +551,15 @@ func (s *stateObject) Code() []byte {
 		s.db.CodeLoadBytes += len(s.code)
 	}(time.Now())
 
+	// Try reading code from the trie first (binary trie stores code in-trie)
+	if s.db.trie != nil {
+		code, err := s.db.trie.GetContractCode(s.address, common.BytesToHash(s.CodeHash()))
+		if err == nil && len(code) > 0 {
+			s.code = code
+			return code
+		}
+	}
+	// Fallback to KV store reader
 	code := s.db.reader.Code(s.address, common.BytesToHash(s.CodeHash()))
 	if len(code) == 0 {
 		s.db.setError(fmt.Errorf("code is not found %x", s.CodeHash()))
@@ -574,6 +583,14 @@ func (s *stateObject) CodeSize() int {
 		s.db.CodeReads += time.Since(start)
 	}(time.Now())
 
+	// Try reading code size from the trie first (binary trie stores it in header)
+	if s.db.trie != nil {
+		size, err := s.db.trie.GetContractCodeSize(s.address)
+		if err == nil && size > 0 {
+			return size
+		}
+	}
+	// Fallback to KV store reader
 	size := s.db.reader.CodeSize(s.address, common.BytesToHash(s.CodeHash()))
 	if size == 0 {
 		s.db.setError(fmt.Errorf("code is not found %x", s.CodeHash()))

--- a/core/state/statedb_fuzz_test.go
+++ b/core/state/statedb_fuzz_test.go
@@ -209,7 +209,7 @@ func (test *stateTest) run() bool {
 		if i != 0 {
 			root = roots[len(roots)-1]
 		}
-		state, err := New(root, NewDatabase(tdb, snaps))
+		state, err := New(root, NewDatabase(tdb, nil).WithSnapshot(snaps))
 		if err != nil {
 			panic(err)
 		}

--- a/core/state/statedb_test.go
+++ b/core/state/statedb_test.go
@@ -1276,7 +1276,7 @@ func TestDeleteStorage(t *testing.T) {
 		disk     = rawdb.NewMemoryDatabase()
 		tdb      = triedb.NewDatabase(disk, nil)
 		snaps, _ = snapshot.New(snapshot.Config{CacheSize: 10}, disk, tdb, types.EmptyRootHash)
-		db       = NewDatabase(tdb, snaps)
+		db       = NewDatabase(tdb, nil).WithSnapshot(snaps)
 		state, _ = New(types.EmptyRootHash, db)
 		addr     = common.HexToAddress("0x1")
 	)
@@ -1290,7 +1290,7 @@ func TestDeleteStorage(t *testing.T) {
 	}
 	root, _ := state.Commit(0, true, false)
 	// Init phase done, create two states, one with snap and one without
-	fastState, _ := New(root, NewDatabase(tdb, snaps))
+	fastState, _ := New(root, NewDatabase(tdb, nil).WithSnapshot(snaps))
 	slowState, _ := New(root, NewDatabase(tdb, nil))
 
 	obj := fastState.getOrNewStateObject(addr)

--- a/core/state/stateupdate.go
+++ b/core/state/stateupdate.go
@@ -211,9 +211,9 @@ func (sc *stateUpdate) deriveCodeFields(reader ContractCodeReader) error {
 	cache := make(map[common.Hash]bool)
 	for addr, code := range sc.codes {
 		if code.originHash != types.EmptyCodeHash {
-			blob, err := reader.Code(addr, code.originHash)
-			if err != nil {
-				return err
+			blob := reader.Code(addr, code.originHash)
+			if len(blob) == 0 {
+				return fmt.Errorf("original code of %x is empty", addr)
 			}
 			code.originBlob = blob
 		}

--- a/core/state/sync_test.go
+++ b/core/state/sync_test.go
@@ -222,8 +222,8 @@ func testIterativeStateSync(t *testing.T, count int, commit bool, bypath bool, s
 			codeResults = make([]trie.CodeSyncResult, len(codeElements))
 		)
 		for i, element := range codeElements {
-			data, err := cReader.Code(common.Address{}, element.code)
-			if err != nil || len(data) == 0 {
+			data := cReader.Code(common.Address{}, element.code)
+			if len(data) == 0 {
 				t.Fatalf("failed to retrieve contract bytecode for hash %x", element.code)
 			}
 			codeResults[i] = trie.CodeSyncResult{Hash: element.code, Data: data}
@@ -346,8 +346,8 @@ func testIterativeDelayedStateSync(t *testing.T, scheme string) {
 		if len(codeElements) > 0 {
 			codeResults := make([]trie.CodeSyncResult, len(codeElements)/2+1)
 			for i, element := range codeElements[:len(codeResults)] {
-				data, err := cReader.Code(common.Address{}, element.code)
-				if err != nil || len(data) == 0 {
+				data := cReader.Code(common.Address{}, element.code)
+				if len(data) == 0 {
 					t.Fatalf("failed to retrieve contract bytecode for %x", element.code)
 				}
 				codeResults[i] = trie.CodeSyncResult{Hash: element.code, Data: data}
@@ -452,8 +452,8 @@ func testIterativeRandomStateSync(t *testing.T, count int, scheme string) {
 		if len(codeQueue) > 0 {
 			results := make([]trie.CodeSyncResult, 0, len(codeQueue))
 			for hash := range codeQueue {
-				data, err := cReader.Code(common.Address{}, hash)
-				if err != nil || len(data) == 0 {
+				data := cReader.Code(common.Address{}, hash)
+				if len(data) == 0 {
 					t.Fatalf("failed to retrieve node data for %x", hash)
 				}
 				results = append(results, trie.CodeSyncResult{Hash: hash, Data: data})
@@ -551,8 +551,8 @@ func testIterativeRandomDelayedStateSync(t *testing.T, scheme string) {
 			for hash := range codeQueue {
 				delete(codeQueue, hash)
 
-				data, err := cReader.Code(common.Address{}, hash)
-				if err != nil || len(data) == 0 {
+				data := cReader.Code(common.Address{}, hash)
+				if len(data) == 0 {
 					t.Fatalf("failed to retrieve node data for %x", hash)
 				}
 				results = append(results, trie.CodeSyncResult{Hash: hash, Data: data})
@@ -671,8 +671,8 @@ func testIncompleteStateSync(t *testing.T, scheme string) {
 		if len(codeQueue) > 0 {
 			results := make([]trie.CodeSyncResult, 0, len(codeQueue))
 			for hash := range codeQueue {
-				data, err := cReader.Code(common.Address{}, hash)
-				if err != nil || len(data) == 0 {
+				data := cReader.Code(common.Address{}, hash)
+				if len(data) == 0 {
 					t.Fatalf("failed to retrieve node data for %x", hash)
 				}
 				results = append(results, trie.CodeSyncResult{Hash: hash, Data: data})

--- a/miner/miner_test.go
+++ b/miner/miner_test.go
@@ -155,7 +155,7 @@ func createMiner(t *testing.T) *Miner {
 	if err != nil {
 		t.Fatalf("can't create new chain %v", err)
 	}
-	statedb, _ := state.New(bc.Genesis().Root(), bc.StateCache())
+	statedb, _ := state.New(bc.Genesis().Root(), state.NewDatabase(bc.TrieDB(), bc.CodeDB()))
 	blockchain := &testBlockChain{bc.Genesis().Root(), chainConfig, statedb, 10000000, new(event.Feed)}
 
 	pool := legacypool.New(testTxPoolConfig, blockchain)

--- a/tests/state_test_util.go
+++ b/tests/state_test_util.go
@@ -546,7 +546,7 @@ func MakePreState(db ethdb.Database, accounts types.GenesisAlloc, snapshotter bo
 		}
 		snaps, _ = snapshot.New(snapconfig, db, triedb, root)
 	}
-	sdb = state.NewDatabase(triedb, snaps)
+	sdb = state.NewDatabase(triedb, nil).WithSnapshot(snaps)
 	statedb, _ = state.New(root, sdb)
 	return StateTestState{statedb, triedb, snaps}
 }

--- a/trie/bintrie/trie.go
+++ b/trie/bintrie/trie.go
@@ -400,6 +400,109 @@ func (t *BinaryTrie) UpdateContractCode(addr common.Address, codeHash common.Has
 	return nil
 }
 
+// GetContractCode retrieves the contract code from the trie by reading
+// and reassembling the chunked code stored via UpdateContractCode.
+func (t *BinaryTrie) GetContractCode(addr common.Address, codeHash common.Hash) ([]byte, error) {
+	// Read the header stem to get code size from BasicData
+	headerKey := GetBinaryTreeKey(addr, zero[:])
+
+	var values [][]byte
+	var err error
+	switch r := t.root.(type) {
+	case *InternalNode:
+		values, err = r.GetValuesAtStem(headerKey[:StemSize], t.nodeResolver)
+	case *StemNode:
+		values = r.Values
+	case Empty:
+		return nil, nil
+	default:
+		return nil, errInvalidRootType
+	}
+	if err != nil {
+		return nil, err
+	}
+	if values == nil || values[BasicDataLeafKey] == nil {
+		return nil, nil
+	}
+
+	// Read code size from BasicData (uint32 big-endian at offset BasicDataCodeSizeOffset-1)
+	codeSize := binary.BigEndian.Uint32(values[BasicDataLeafKey][BasicDataCodeSizeOffset-1 : BasicDataCodeSizeOffset+3])
+	if codeSize == 0 {
+		return nil, nil
+	}
+
+	// Calculate number of chunks
+	chunkCount := (int(codeSize) + StemSize - 1) / StemSize
+	code := make([]byte, 0, codeSize)
+
+	var currentValues [][]byte
+	for chunknr := uint64(0); chunknr < uint64(chunkCount); chunknr++ {
+		groupOffset := (chunknr + 128) % StemNodeWidth
+
+		if groupOffset == 0 || chunknr == 0 {
+			// Need to read a new stem
+			var offset [HashSize]byte
+			binary.LittleEndian.PutUint64(offset[24:], chunknr+128)
+			key := GetBinaryTreeKey(addr, offset[:])
+
+			switch r := t.root.(type) {
+			case *InternalNode:
+				currentValues, err = r.GetValuesAtStem(key[:StemSize], t.nodeResolver)
+			case *StemNode:
+				currentValues = r.Values
+			default:
+				return nil, fmt.Errorf("GetContractCode: unexpected root type %T", t.root)
+			}
+			if err != nil {
+				return nil, fmt.Errorf("GetContractCode (addr=%x chunk=%d) error: %w", addr[:], chunknr, err)
+			}
+		}
+
+		if currentValues == nil || currentValues[groupOffset] == nil {
+			return nil, fmt.Errorf("GetContractCode (addr=%x): missing chunk %d", addr[:], chunknr)
+		}
+
+		chunk := currentValues[groupOffset]
+		// Skip the first byte (pushdata metadata), take StemSize bytes of actual code
+		if len(chunk) > 1 {
+			code = append(code, chunk[1:]...)
+		}
+	}
+
+	// Truncate to actual code size
+	if len(code) > int(codeSize) {
+		code = code[:codeSize]
+	}
+	return code, nil
+}
+
+// GetContractCodeSize returns the size of the contract code without reading the chunks.
+func (t *BinaryTrie) GetContractCodeSize(addr common.Address) (int, error) {
+	headerKey := GetBinaryTreeKey(addr, zero[:])
+
+	var values [][]byte
+	var err error
+	switch r := t.root.(type) {
+	case *InternalNode:
+		values, err = r.GetValuesAtStem(headerKey[:StemSize], t.nodeResolver)
+	case *StemNode:
+		values = r.Values
+	case Empty:
+		return 0, nil
+	default:
+		return 0, errInvalidRootType
+	}
+	if err != nil {
+		return 0, err
+	}
+	if values == nil || values[BasicDataLeafKey] == nil {
+		return 0, nil
+	}
+
+	codeSize := binary.BigEndian.Uint32(values[BasicDataLeafKey][BasicDataCodeSizeOffset-1 : BasicDataCodeSizeOffset+3])
+	return int(codeSize), nil
+}
+
 // PrefetchAccount attempts to resolve specific accounts from the database
 // to accelerate subsequent trie operations.
 func (t *BinaryTrie) PrefetchAccount(addresses []common.Address) error {

--- a/trie/secure_trie.go
+++ b/trie/secure_trie.go
@@ -230,6 +230,16 @@ func (t *StateTrie) UpdateContractCode(_ common.Address, _ common.Hash, _ []byte
 	return nil
 }
 
+// GetContractCode is a no-op for MPT tries (code is stored separately in KV store).
+func (t *StateTrie) GetContractCode(_ common.Address, _ common.Hash) ([]byte, error) {
+	return nil, nil
+}
+
+// GetContractCodeSize is a no-op for MPT tries (code size is stored separately).
+func (t *StateTrie) GetContractCodeSize(_ common.Address) (int, error) {
+	return 0, nil
+}
+
 // MustDelete removes any existing value for key from the trie. This function
 // will omit any encountered error but just print out an error message.
 func (t *StateTrie) MustDelete(key []byte) {

--- a/trie/transitiontrie/transition.go
+++ b/trie/transitiontrie/transition.go
@@ -231,6 +231,16 @@ func (t *TransitionTrie) UpdateContractCode(addr common.Address, codeHash common
 	return t.overlay.UpdateContractCode(addr, codeHash, code)
 }
 
+// GetContractCode retrieves the contract code from the overlay binary trie.
+func (t *TransitionTrie) GetContractCode(addr common.Address, codeHash common.Hash) ([]byte, error) {
+	return t.overlay.GetContractCode(addr, codeHash)
+}
+
+// GetContractCodeSize returns the code size from the overlay binary trie.
+func (t *TransitionTrie) GetContractCodeSize(addr common.Address) (int, error) {
+	return t.overlay.GetContractCodeSize(addr)
+}
+
 // Witness returns a set containing all trie nodes that have been accessed.
 func (t *TransitionTrie) Witness() map[string][]byte {
 	panic("not implemented")

--- a/triedb/hashdb/database.go
+++ b/triedb/hashdb/database.go
@@ -612,6 +612,9 @@ func (db *Database) Close() error {
 // NodeReader returns a reader for accessing trie nodes within the specified state.
 // An error will be returned if the specified state is not available.
 func (db *Database) NodeReader(root common.Hash) (database.NodeReader, error) {
+	if root == types.EmptyRootHash {
+		return &reader{db: db}, nil
+	}
 	if _, err := db.node(root); err != nil {
 		return nil, fmt.Errorf("state %#x is not available, %v", root, err)
 	}


### PR DESCRIPTION
This PR adds support for reading contract code directly from the binary trie (EIP-7864), complementing the `CodeDB` refactoring.

## Motivation

In binary trie mode, contract code is already stored in the trie as chunks via `UpdateContractCode`. However, there was no corresponding read path — code was always read from the separate KV store via `CodeDB`. This is redundant for binary tries and would prevent a clean transition to code-in-trie.

## Changes

- **`trie/bintrie/trie.go`**: Add `GetContractCode(addr, codeHash)` which reads the code size from BasicData, iterates through chunked code slots (skipping pushdata metadata), and reassembles the full bytecode. Add `GetContractCodeSize(addr)` which reads only the header.
- **`core/state/database.go`**: Extend `Trie` interface with `GetContractCode` and `GetContractCodeSize`. Skip KV code writes in `Commit()` when `IsVerkle()`.
- **`trie/secure_trie.go`**: No-op implementations for MPT.
- **`trie/transitiontrie/transition.go`**: Delegate to overlay binary trie.
- **`core/state/state_object.go`**: `Code()` and `CodeSize()` try the trie first, falling back to the KV store reader.

All existing tests pass. Backward compatible: MPT mode is unchanged.