### PR TITLE
core/state: plumb CodeSize through AccountMut for binaryHasher

### DIFF
--- a/core/state/database_hasher.go
+++ b/core/state/database_hasher.go
@@ -33,9 +33,19 @@ type CodeMut struct {
 // - Account == nil: delete the account
 // - Code == nil:  leave code unchanged
 // - Code != nil: apply the given code mutation
+// - CodeSize: the account's CURRENT total code size, not just the bytes
+//   carried in Code. It is used by implementations that pack the code
+//   size into their on-trie account encoding (e.g. the binary trie
+//   BasicData leaf). Callers must always populate this field to the
+//   account's real code size, obtained via stateObject.CodeSize() or an
+//   equivalent source — even on balance/nonce-only updates where the
+//   code bytes themselves are not loaded. Leaving it at zero on a
+//   non-code-touching update silently corrupts on-trie state for any
+//   hasher that stores code size.
 type AccountMut struct {
-	Account *Account // Null for deletion
-	Code    *CodeMut // Null for unchanged
+	Account  *Account // Null for deletion
+	Code     *CodeMut // Null for unchanged
+	CodeSize int      // Current code length (must be set by the caller)
 }
 
 // Hashes encapsulates a trie root together with its original (pre-update) root.

--- a/core/state/database_hasher_binary.go
+++ b/core/state/database_hasher_binary.go
@@ -153,22 +153,25 @@ func (h *binaryHasher) deleteAccount(addr common.Address) error {
 }
 
 // update writes the account specified by the address into the state.
+//
+// The account's code size is taken from AccountMut.CodeSize, which the
+// caller (StateDB.IntermediateRoot) populates via stateObject.CodeSize().
+// Per EIP-7864 the code_size field is packed into the BasicData leaf
+// (bytes 5-7) and is consensus-critical; BinaryTrie.UpdateAccount rewrites
+// the entire BasicData blob on every call, so passing the wrong codeLen
+// would silently overwrite the stored code_size. In particular, for
+// balance/nonce-only updates the new code bytes (account.Code) are nil
+// and len(obj.code) is 0, yet the account may still have a non-zero code
+// size that must be preserved — the caller gets this right by consulting
+// the stateObject, which falls back to a reader code-size lookup when
+// the bytes are not loaded.
 func (h *binaryHasher) updateAccount(addr common.Address, account AccountMut) error {
-	// Determine code size: use the new code length if provided,
-	// otherwise fall back to the cached or trie-stored value.
-	//
-	// TODO(rjl493456442) the contract code length is not assigned
-	// if it's not modified, fix it.
-	codeLen := 0
-	if account.Code != nil {
-		codeLen = len(account.Code.Code)
-	}
 	data := &types.StateAccount{
 		Nonce:    account.Account.Nonce,
 		Balance:  account.Account.Balance,
 		CodeHash: account.Account.CodeHash,
 	}
-	if err := h.trie.UpdateAccount(addr, data, codeLen); err != nil {
+	if err := h.trie.UpdateAccount(addr, data, account.CodeSize); err != nil {
 		return err
 	}
 	// Write chunked code into the trie when dirty.

--- a/core/state/database_hasher_binary.go
+++ b/core/state/database_hasher_binary.go
@@ -17,6 +17,8 @@
 package state
 
 import (
+	"fmt"
+
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/stateless"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -157,15 +159,29 @@ func (h *binaryHasher) deleteAccount(addr common.Address) error {
 // The account's code size is taken from AccountMut.CodeSize, which the
 // caller (StateDB.IntermediateRoot) populates via stateObject.CodeSize().
 // Per EIP-7864 the code_size field is packed into the BasicData leaf
-// (bytes 5-7) and is consensus-critical; BinaryTrie.UpdateAccount rewrites
-// the entire BasicData blob on every call, so passing the wrong codeLen
-// would silently overwrite the stored code_size. In particular, for
-// balance/nonce-only updates the new code bytes (account.Code) are nil
-// and len(obj.code) is 0, yet the account may still have a non-zero code
-// size that must be preserved — the caller gets this right by consulting
-// the stateObject, which falls back to a reader code-size lookup when
-// the bytes are not loaded.
+// (see trie/bintrie/trie.go:UpdateAccount and the BasicDataCodeSizeOffset
+// constant in trie/bintrie/key_encoding.go for the exact byte layout)
+// and is consensus-critical; BinaryTrie.UpdateAccount rewrites the entire
+// BasicData blob on every call, so passing the wrong codeLen would
+// silently overwrite the stored code_size. In particular, for
+// balance/nonce-only updates account.Code is nil (the caller only
+// populates it when obj.dirtyCode is true), so the previous
+// implementation, which derived codeLen from len(account.Code.Code),
+// produced 0 even though the account still had a real non-zero code
+// size that must be preserved. The caller now consults the stateObject,
+// which falls back to a reader code-size lookup when the bytes are
+// not loaded.
 func (h *binaryHasher) updateAccount(addr common.Address, account AccountMut) error {
+	// Defensive invariant: CodeSize must match the account's current
+	// code size. A zero CodeSize combined with a non-empty CodeHash
+	// indicates the caller forgot to populate it, which would silently
+	// overwrite the EIP-7864 BasicData code_size field. Fail loudly so
+	// the original fixed bug cannot be re-introduced by a new caller
+	// that constructs AccountMut{Account: &x} without setting CodeSize.
+	if common.BytesToHash(account.Account.CodeHash) != types.EmptyCodeHash && account.CodeSize == 0 {
+		return fmt.Errorf("binaryHasher: CodeSize unset for contract %x (codeHash %x)",
+			addr, account.Account.CodeHash)
+	}
 	data := &types.StateAccount{
 		Nonce:    account.Account.Nonce,
 		Balance:  account.Account.Balance,

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -806,6 +806,18 @@ func (s *StateDB) IntermediateRoot(deleteEmptyObjects bool) common.Hash {
 		accounts = append(accounts, mut)
 		s.AccountUpdated += 1
 	}
+	// If any prior step (storage-reader Wait above, or the obj.CodeSize()
+	// reader-fallback in the mutations loop) recorded an error in s.dbErr,
+	// the collected AccountMut entries may contain a zero CodeSize for a
+	// contract whose code blob is missing. Running the hasher with those
+	// would silently corrupt the BasicData leaves of every affected
+	// contract. Fail loudly by returning an empty root; the error is
+	// already recorded in s.dbErr and will be surfaced by Commit. This
+	// also catches the pre-existing silent-continue after workers.Wait()
+	// on storage-reader failures.
+	if s.dbErr != nil {
+		return common.Hash{}
+	}
 	if err := s.hasher.UpdateAccount(addresses, accounts); err != nil {
 		s.setError(err)
 		return common.Hash{}

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -784,7 +784,18 @@ func (s *StateDB) IntermediateRoot(deleteEmptyObjects bool) common.Hash {
 			continue
 		}
 		obj := s.stateObjects[addr]
-		mut := AccountMut{Account: &obj.data}
+		// CodeSize must be the account's CURRENT total code size, even for
+		// non-code-touching mutations. obj.CodeSize() returns len(obj.code)
+		// when the code is loaded, otherwise falls back to a code-size
+		// lookup via the reader. Hashers that pack code size into the
+		// on-trie account encoding (e.g. the binary trie BasicData leaf,
+		// per EIP-7864) rely on this value. Passing the default 0 here on
+		// a balance/nonce-only update would silently corrupt the BasicData
+		// leaf of every contract touched without a code write.
+		mut := AccountMut{
+			Account:  &obj.data,
+			CodeSize: obj.CodeSize(),
+		}
 		if obj.dirtyCode {
 			mut.Code = &CodeMut{Code: obj.code}
 

--- a/core/state/statedb_test.go
+++ b/core/state/statedb_test.go
@@ -1266,3 +1266,85 @@ func TestStorageDirtiness(t *testing.T) {
 	state.RevertToSnapshot(snap)
 	checkDirty(common.Hash{0x1}, common.Hash{0x1}, true)
 }
+
+// TestVerkleCodeSizePreserved is a regression test for a latent bug in the
+// binary-trie update path of binaryHasher: codeLen was derived from
+// account.Code, which is only non-nil when the contract code itself was
+// modified in the current block. For balance- or nonce-only changes,
+// account.Code was nil and the hasher silently wrote codeLen=0 into the
+// BasicData leaf, corrupting the EIP-7864-defined code_size field every
+// time a contract's balance or nonce was touched without a code write.
+//
+// The fix plumbs the account's current total code size through
+// AccountMut.CodeSize, which the caller populates via
+// stateObject.CodeSize() at commit time. This value is authoritative
+// whether or not the code bytes are currently loaded.
+//
+// This test verifies that the state root produced by "create contract,
+// commit, reload, modify balance, commit" matches the state root produced
+// by a single commit of the final state. Equality can only hold if the
+// code size survives the balance-only commit.
+func TestVerkleCodeSizePreserved(t *testing.T) {
+	newVerkleState := func(t *testing.T) (*StateDB, *triedb.Database) {
+		t.Helper()
+		disk := rawdb.NewMemoryDatabase()
+		tdb := triedb.NewDatabase(disk, triedb.VerkleDefaults)
+		sdb := NewDatabase(tdb, nil)
+		// A fresh verkle pathdb's disk layer is keyed by EmptyVerkleHash
+		// (all-zero hash), not EmptyRootHash. Using the wrong one fails
+		// with "triedb parent layer missing" at commit.
+		state, err := New(types.EmptyVerkleHash, sdb)
+		if err != nil {
+			t.Fatalf("failed to initialize state: %v", err)
+		}
+		return state, tdb
+	}
+
+	var (
+		addr = common.HexToAddress("0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef")
+		code = make([]byte, 1234) // non-trivial code length so codeSize matters
+	)
+	for i := range code {
+		code[i] = byte(i)
+	}
+
+	// Path A: create contract, commit, reload, modify only balance, commit.
+	// On the second commit obj.code is not loaded (dirtyCode=false), so
+	// the previous implementation computed codeLen=0 via len(obj.code).
+	// Triedb layers stay in memory (no tdb.Commit) so we can chain a
+	// second block on top of the first.
+	stateA, tdbA := newVerkleState(t)
+	sdbA := NewDatabase(tdbA, nil)
+	stateA.SetBalance(addr, uint256.NewInt(100), tracing.BalanceChangeUnspecified)
+	stateA.SetCode(addr, code, tracing.CodeChangeUnspecified)
+	rootA1, err := stateA.Commit(0, true, false)
+	if err != nil {
+		t.Fatalf("path A first commit: %v", err)
+	}
+
+	stateA, err = New(rootA1, sdbA)
+	if err != nil {
+		t.Fatalf("path A reload: %v", err)
+	}
+	stateA.SetBalance(addr, uint256.NewInt(200), tracing.BalanceChangeUnspecified)
+	rootA2, err := stateA.Commit(1, true, false)
+	if err != nil {
+		t.Fatalf("path A second commit: %v", err)
+	}
+
+	// Path B: construct the same final state in one shot (balance=200 + code).
+	// obj.code is loaded because SetCode was just called, so codeSize is
+	// always correct here — this is the "known-good" reference.
+	stateB, _ := newVerkleState(t)
+	stateB.SetBalance(addr, uint256.NewInt(200), tracing.BalanceChangeUnspecified)
+	stateB.SetCode(addr, code, tracing.CodeChangeUnspecified)
+	rootB, err := stateB.Commit(0, true, false)
+	if err != nil {
+		t.Fatalf("path B commit: %v", err)
+	}
+
+	if rootA2 != rootB {
+		t.Fatalf("state root mismatch after balance-only update:\n  path A (reload + balance): %x\n  path B (fresh, same final state): %x\n  regression: binaryHasher.updateAccount used len(account.Code.Code)=0 because code was not modified",
+			rootA2, rootB)
+	}
+}

--- a/core/state/statedb_test.go
+++ b/core/state/statedb_test.go
@@ -1267,8 +1267,8 @@ func TestStorageDirtiness(t *testing.T) {
 	checkDirty(common.Hash{0x1}, common.Hash{0x1}, true)
 }
 
-// TestVerkleCodeSizePreserved is a regression test for a latent bug in the
-// binary-trie update path of binaryHasher: codeLen was derived from
+// TestBinaryCodeSizePreserved is a regression test for a latent bug in
+// the bintrie update path of binaryHasher: codeLen was derived from
 // account.Code, which is only non-nil when the contract code itself was
 // modified in the current block. For balance- or nonce-only changes,
 // account.Code was nil and the hasher silently wrote codeLen=0 into the
@@ -1284,15 +1284,20 @@ func TestStorageDirtiness(t *testing.T) {
 // commit, reload, modify balance, commit" matches the state root produced
 // by a single commit of the final state. Equality can only hold if the
 // code size survives the balance-only commit.
-func TestVerkleCodeSizePreserved(t *testing.T) {
-	newVerkleState := func(t *testing.T) (*StateDB, *triedb.Database) {
+//
+// Note: triedb.VerkleDefaults and types.EmptyVerkleHash are legacy names
+// from when the binary trie work was branched off the verkle trie code;
+// they configure and seed the bintrie scheme used by binaryHasher.
+func TestBinaryCodeSizePreserved(t *testing.T) {
+	newBinaryState := func(t *testing.T) (*StateDB, *triedb.Database) {
 		t.Helper()
 		disk := rawdb.NewMemoryDatabase()
 		tdb := triedb.NewDatabase(disk, triedb.VerkleDefaults)
 		sdb := NewDatabase(tdb, nil)
-		// A fresh verkle pathdb's disk layer is keyed by EmptyVerkleHash
-		// (all-zero hash), not EmptyRootHash. Using the wrong one fails
-		// with "triedb parent layer missing" at commit.
+		// A fresh bintrie pathdb's disk layer is keyed by EmptyVerkleHash
+		// (all-zero hash, named "Verkle" for legacy reasons), not
+		// EmptyRootHash. Using the wrong one fails with "triedb parent
+		// layer missing" at commit.
 		state, err := New(types.EmptyVerkleHash, sdb)
 		if err != nil {
 			t.Fatalf("failed to initialize state: %v", err)
@@ -1313,7 +1318,7 @@ func TestVerkleCodeSizePreserved(t *testing.T) {
 	// the previous implementation computed codeLen=0 via len(obj.code).
 	// Triedb layers stay in memory (no tdb.Commit) so we can chain a
 	// second block on top of the first.
-	stateA, tdbA := newVerkleState(t)
+	stateA, tdbA := newBinaryState(t)
 	sdbA := NewDatabase(tdbA, nil)
 	stateA.SetBalance(addr, uint256.NewInt(100), tracing.BalanceChangeUnspecified)
 	stateA.SetCode(addr, code, tracing.CodeChangeUnspecified)
@@ -1335,7 +1340,7 @@ func TestVerkleCodeSizePreserved(t *testing.T) {
 	// Path B: construct the same final state in one shot (balance=200 + code).
 	// obj.code is loaded because SetCode was just called, so codeSize is
 	// always correct here — this is the "known-good" reference.
-	stateB, _ := newVerkleState(t)
+	stateB, _ := newBinaryState(t)
 	stateB.SetBalance(addr, uint256.NewInt(200), tracing.BalanceChangeUnspecified)
 	stateB.SetCode(addr, code, tracing.CodeChangeUnspecified)
 	rootB, err := stateB.Commit(0, true, false)

--- a/core/state/statedb_test.go
+++ b/core/state/statedb_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/ethereum/go-ethereum/core/tracing"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/triedb"
 	"github.com/ethereum/go-ethereum/triedb/hashdb"
 	"github.com/ethereum/go-ethereum/triedb/pathdb"
@@ -1314,10 +1315,12 @@ func TestBinaryCodeSizePreserved(t *testing.T) {
 	}
 
 	// Path A: create contract, commit, reload, modify only balance, commit.
-	// On the second commit obj.code is not loaded (dirtyCode=false), so
-	// the previous implementation computed codeLen=0 via len(obj.code).
-	// Triedb layers stay in memory (no tdb.Commit) so we can chain a
-	// second block on top of the first.
+	// On the second commit obj.dirtyCode is false, so account.Code is nil
+	// when the binary hasher receives the AccountMut. The previous
+	// implementation derived codeLen from len(account.Code.Code) and got 0,
+	// silently overwriting the BasicData code_size field.
+	// Triedb layers stay in pathdb memory (the test never calls
+	// triedb.Commit) so we can chain a second block on top of the first.
 	stateA, tdbA := newBinaryState(t)
 	sdbA := NewDatabase(tdbA, nil)
 	stateA.SetBalance(addr, uint256.NewInt(100), tracing.BalanceChangeUnspecified)
@@ -1350,6 +1353,149 @@ func TestBinaryCodeSizePreserved(t *testing.T) {
 
 	if rootA2 != rootB {
 		t.Fatalf("state root mismatch after balance-only update:\n  path A (reload + balance): %x\n  path B (fresh, same final state): %x\n  regression: binaryHasher.updateAccount used len(account.Code.Code)=0 because code was not modified",
+			rootA2, rootB)
+	}
+}
+
+// TestBinaryCodeSizeMissingFailsLoudly is the complementary regression
+// test to TestBinaryCodeSizePreserved: it verifies that when a contract's
+// code blob is unreachable (disk eviction, pruning, corrupt pathdb layer),
+// the IntermediateRoot path fails loudly via the s.dbErr guard rather
+// than silently writing a zero code_size into the BasicData leaf.
+//
+// Without the guard, stateObject.CodeSize() returns 0 on a reader miss,
+// flows through AccountMut.CodeSize, and corrupts the BasicData leaf —
+// the exact bug class the parent fix closes, just triggered differently.
+//
+// The assertion targets IntermediateRoot directly (not just Commit)
+// because commit() already has its own dbErr check that would mask a
+// missing IntermediateRoot guard. Only block proposers calling
+// IntermediateRoot directly need the in-function guard.
+func TestBinaryCodeSizeMissingFailsLoudly(t *testing.T) {
+	var (
+		addr = common.HexToAddress("0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef")
+		code = make([]byte, 1234)
+	)
+	for i := range code {
+		code[i] = byte(i)
+	}
+	codeHash := crypto.Keccak256Hash(code)
+
+	disk := rawdb.NewMemoryDatabase()
+	tdb := triedb.NewDatabase(disk, triedb.VerkleDefaults)
+
+	// Phase 1: create + commit the contract with code.
+	sdb1 := NewDatabase(tdb, nil)
+	state1, err := New(types.EmptyVerkleHash, sdb1)
+	if err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	state1.SetBalance(addr, uint256.NewInt(100), tracing.BalanceChangeUnspecified)
+	state1.SetCode(addr, code, tracing.CodeChangeUnspecified)
+	root1, err := state1.Commit(0, true, false)
+	if err != nil {
+		t.Fatalf("first commit: %v", err)
+	}
+
+	// Phase 2: delete the code blob from disk. The account still
+	// references it via CodeHash, but no reader will be able to
+	// resolve it.
+	rawdb.DeleteCode(disk, codeHash)
+
+	// Phase 3: reload with a FRESH CodeDB (empty codeSizeCache) so
+	// the deletion actually takes effect. Reusing sdb1 would hit the
+	// cached size entry and mask the failure — codeSizeCache has no
+	// public eviction API, so creating a fresh CodeDB is the only
+	// way to force a disk read on the next CodeSize() lookup.
+	sdb2 := NewDatabase(tdb, NewCodeDB(disk))
+	state2, err := New(root1, sdb2)
+	if err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	state2.SetBalance(addr, uint256.NewInt(200), tracing.BalanceChangeUnspecified)
+
+	// Phase 4a: IntermediateRoot (the path consensus engines use
+	// directly) must return common.Hash{} on reader miss — this is
+	// the property the dbErr guard in IntermediateRoot guarantees.
+	// Without the guard this would return a corrupt-but-plausible
+	// hash with code_size=0 packed into the BasicData leaf.
+	root := state2.IntermediateRoot(true)
+	if root != (common.Hash{}) {
+		t.Fatalf("expected IntermediateRoot to return empty hash on reader miss, got %x", root)
+	}
+	// Phase 4b: state.Error() must carry the "code is not found"
+	// error recorded by stateObject.CodeSize().
+	if state2.Error() == nil {
+		t.Fatalf("expected state.Error() != nil after reader miss, got nil")
+	}
+}
+
+// TestBinaryCodeSizeStoragePreserved is a regression test that mirrors
+// TestBinaryCodeSizePreserved but uses SetState as the second-block
+// trigger. Storage writes are the dominant real-world path for
+// "contract touched without code reload" — every ERC20 transfer fits
+// this pattern — and they flow through updateTrie/workers.Go, a
+// different code path than SetBalance. Both paths must preserve the
+// account's code_size across a balance-less recommit.
+func TestBinaryCodeSizeStoragePreserved(t *testing.T) {
+	newBinaryState := func(t *testing.T) (*StateDB, *triedb.Database) {
+		t.Helper()
+		disk := rawdb.NewMemoryDatabase()
+		tdb := triedb.NewDatabase(disk, triedb.VerkleDefaults)
+		sdb := NewDatabase(tdb, nil)
+		state, err := New(types.EmptyVerkleHash, sdb)
+		if err != nil {
+			t.Fatalf("failed to initialize state: %v", err)
+		}
+		return state, tdb
+	}
+
+	var (
+		addr = common.HexToAddress("0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef")
+		code = make([]byte, 1234)
+		slot = common.HexToHash("0x01")
+		val1 = common.HexToHash("0x0a")
+		val2 = common.HexToHash("0x0b")
+	)
+	for i := range code {
+		code[i] = byte(i)
+	}
+
+	// Path A: create contract + initial storage, commit, reload, modify
+	// only storage, commit. On the second commit obj.dirtyCode is false
+	// and account.Code is nil, so stateObject.CodeSize() must fall back
+	// to the reader to recover the real code size.
+	stateA, tdbA := newBinaryState(t)
+	sdbA := NewDatabase(tdbA, nil)
+	stateA.SetCode(addr, code, tracing.CodeChangeUnspecified)
+	stateA.SetState(addr, slot, val1)
+	rootA1, err := stateA.Commit(0, true, false)
+	if err != nil {
+		t.Fatalf("path A first commit: %v", err)
+	}
+
+	stateA, err = New(rootA1, sdbA)
+	if err != nil {
+		t.Fatalf("path A reload: %v", err)
+	}
+	stateA.SetState(addr, slot, val2)
+	rootA2, err := stateA.Commit(1, true, false)
+	if err != nil {
+		t.Fatalf("path A second commit: %v", err)
+	}
+
+	// Path B: construct the same final state in one shot (code + slot=val2).
+	// obj.code is loaded via SetCode, so CodeSize() hits the fast path.
+	stateB, _ := newBinaryState(t)
+	stateB.SetCode(addr, code, tracing.CodeChangeUnspecified)
+	stateB.SetState(addr, slot, val2)
+	rootB, err := stateB.Commit(0, true, false)
+	if err != nil {
+		t.Fatalf("path B commit: %v", err)
+	}
+
+	if rootA2 != rootB {
+		t.Fatalf("state root mismatch after storage-only update:\n  path A (reload + storage): %x\n  path B (fresh, same final state): %x",
 			rootA2, rootB)
 	}
 }


### PR DESCRIPTION
## Summary

`binaryHasher.updateAccount` computed `codeLen` from `len(account.Code.Code)`, which is only non-zero when the code itself was modified in the current block. For balance- or nonce-only updates `account.Code` is nil and the computed `codeLen` was 0, **silently overwriting the `code_size` field packed into the bintrie BasicData leaf** (EIP-7864 bytes 5-7) with zero every time a contract was touched without a code write.

The `TODO(rjl493456442)` on `updateAccount` is addressed here

## Fix

Add a `CodeSize int` field to `AccountMut` and have the caller at `StateDB.IntermediateRoot` populate it via `stateObject.CodeSize()`, which returns `len(obj.code)` when the bytes are loaded, otherwise falls back to a code-size lookup via the reader. The binary hasher then passes `account.CodeSize` straight to `BinaryTrie.UpdateAccount` as its `codeLen` argument, and the TODO is removed.


## MPT path

`merkleHasher` is unaffected: `StateTrie.UpdateAccount` ignores its `codeLen` parameter, so the `wrapTrie.UpdateAccount` shim continues to pass 0 and no state-root divergence is introduced on the MPT path.

## Related

- A parallel PR ([ethereum/go-ethereum#34677](https://github.com/ethereum/go-ethereum/pull/34677)) fixes the same latent bug on `master`'s `updateStateObject`, which passes `len(obj.code)` to `trie.UpdateAccount` — same root cause, different call site. The two fixes are independent and target different branches.
- A sibling PR ([ethereum/go-ethereum#34676](https://github.com/ethereum/go-ethereum/pull/34676)) fixes `BinaryTrie.DeleteAccount` which is currently a no-op. Together these three bugfixes unblock ongoing bintrie flat-state work.